### PR TITLE
feat: add an `index: <name>` input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   selftest-exchange-only-index:
+    name: "Test: ensure that token exchange works with the `index` input"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -47,6 +48,7 @@ jobs:
           index: main
 
   selftest-exchange-only-upload-url:
+    name: "Test: ensure that token exchange works with the `url` input"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -80,6 +82,7 @@ jobs:
           PYX_UPLOAD_URL: ${{ env.PYX_UPLOAD_URL }}
 
   selftest-exchange-only-workspace:
+    name: "Test: ensure that token exchange works with the `workspace` and `registry` inputs"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -104,6 +107,7 @@ jobs:
           registry: main
 
   selftest-exchange-only-workspace-default-registry:
+    name: "Test: ensure that token exchange works with the `workspace` input and default registry"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -126,7 +130,52 @@ jobs:
         with:
           workspace: pyx-auth-action
 
+  selftest-inputs-index-no-publish-url-xfail:
+    name: "Test: expect failure when using `index` input but configured index has no publish-url"
+    if: |-
+      ${{
+          github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
+          github.event_name == 'push'
+       }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for testing the action itself
+      contents: read # for private repos
+
+    environment: test
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Create a dummy pyproject.toml without publish-url
+        run: |
+          cat <<EOF >> pyproject.toml
+
+          [[tool.uv.index]]
+          name = "main"
+          url = "https://astral-sh-staging-api.pyx.dev/simple/pyx-auth-action/main"
+          EOF
+
+      - name: Expect failure when index has no publish-url
+        uses: ./
+        id: auth
+        continue-on-error: true
+        with:
+          index: main
+
+      - name: Check failure
+        run: |
+          if [ "${OUTCOME}" != "failure" ]; then
+            echo "Expected failure, got '${OUTCOME}'"
+            exit 1
+          fi
+        env:
+          OUTCOME: ${{ steps.auth.outcome }}
+
   selftest-inputs-mutex-xfail:
+    name: "Test: expect failure when both `url` and `workspace`/`registry` are provided"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -163,6 +212,7 @@ jobs:
           OUTCOME: ${{ steps.auth.outcome }}
 
   selftest-publish-e2e:
+    name: "Test: end-to-end publish using the action to get a token"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -215,6 +265,7 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ steps.auth.outputs.token }}
 
   selftest-publish-e2e-workspace-default-registry:
+    name: "Test: end-to-end publish using the action with `workspace` input and default registry"
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -267,6 +318,7 @@ jobs:
           UV_PUBLISH_TOKEN: ${{ steps.auth.outputs.token }}
 
   all-tests-pass:
+    name: "Ensure all selftests pass"
     if: always()
 
     needs:
@@ -274,6 +326,7 @@ jobs:
       - selftest-exchange-only-upload-url
       - selftest-exchange-only-workspace-default-registry
       - selftest-exchange-only-workspace
+      - selftest-inputs-index-no-publish-url-xfail
       - selftest-inputs-mutex-xfail
       - selftest-publish-e2e
       - selftest-publish-e2e-workspace-default-registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
 
           [[tool.uv.index]]
           name = "main"
+          url = "https://api.pyx.dev/simple/pyx-auth-action/main"
           publish-url = "https://api.pyx.dev/v1/upload/pyx-auth-action/main"
           EOF
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,8 @@ jobs:
 
           [[tool.uv.index]]
           name = "main"
-          url = "https://api.pyx.dev/simple/pyx-auth-action/main"
-          publish-url = "https://api.pyx.dev/v1/upload/pyx-auth-action/main"
+          url = "https://astral-sh-staging-api.pyx.dev/simple/pyx-auth-action/main"
+          publish-url = "https://astral-sh-staging-api.pyx.dev/v1/upload/pyx-auth-action/main"
           EOF
 
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,14 +36,14 @@ jobs:
           cat <<EOF >> pyproject.toml
 
           [[tool.uv.index]]
-          name = "pyx-auth-action/main"
+          name = "main"
           publish-url = "https://api.pyx.dev/v1/upload/pyx-auth-action/main"
           EOF
 
       - uses: ./
         id: auth
         with:
-          index: pyx-auth-action/main
+          index: main
 
   selftest-exchange-only-upload-url:
     if: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,39 @@ env:
   GHA_PYX_INPUT_INTERNAL_API_BASE: https://astral-sh-staging-api.pyx.dev
 
 jobs:
-  selftest-exchange-only:
+  selftest-exchange-only-index:
+    if: |-
+      ${{
+          github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
+          github.event_name == 'push'
+       }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for testing the action itself
+      contents: read # for private repos
+
+    environment: test
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Create a dummy pyproject.toml with publish-url
+        run: |
+          cat <<EOF >> pyproject.toml
+
+          [[tool.uv.index]]
+          name = "pyx-auth-action/main"
+          publish-url = "https://api.pyx.dev/v1/upload/pyx-auth-action/main"
+          EOF
+
+      - uses: ./
+        id: auth
+        with:
+          index: pyx-auth-action/main
+
+  selftest-exchange-only-upload-url:
     if: |-
       ${{
           github.event.pull_request.head.repo.full_name == 'astral-sh/pyx-auth-action' ||
@@ -237,7 +269,8 @@ jobs:
     if: always()
 
     needs:
-      - selftest-exchange-only
+      - selftest-exchange-only-index
+      - selftest-exchange-only-upload-url
       - selftest-exchange-only-workspace-default-registry
       - selftest-exchange-only-workspace
       - selftest-inputs-mutex-xfail

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Refer to the [pyx documentation](TODO) for more information.
   - [Use your workspace's default registry](#use-your-workspaces-default-registry)
   - [Pass the upload URL explicitly](#pass-the-upload-url-explicitly)
 - [Inputs](#inputs)
+  - [`index`](#index)
   - [`workspace`](#workspace)
   - [`registry`](#registry)
   - [`url`](#url-input)
@@ -43,8 +44,19 @@ permissions:
 
 ### Quickstart
 
-Use the `workspace` and `registry` inputs to tell pyx which workspace
-and registry you intend to publish to:
+Use the `[[tool.uv.index]]` section in your `pyproject.toml` to configure
+your pyx registry:
+
+```toml
+[[tool.uv.index]]
+name = "main"
+url = "https://api.pyx.dev/simple/acme/main"
+publish-url = "https://api.pyx.dev/v1/upload/acme/main"
+```
+
+(Replace `acme` and `main` with your workspace and registry names.)
+
+Then, use the `index` input to tell pyx which index you intend to publish to:
 
 ```yaml
 jobs:
@@ -57,8 +69,7 @@ jobs:
       - uses: astral-sh/pyx-auth-action@72c349389064ca0c0550f640971537eabc648de4 # v0.0.2
         id: auth
         with:
-          workspace: acme
-          registry: main
+          index: main
 
       - run: uv publish
         env:
@@ -67,6 +78,10 @@ jobs:
 ```
 
 ### Use your workspace's default registry
+
+If you don't want to use the `[[tool.uv.index]]` section in your
+`pyproject.toml`, you can specify the `workspace` and `registry` inputs
+directly.
 
 If you're publishing to your workspace's default registry, you can omit the
 `registry` input:
@@ -102,11 +117,21 @@ directly:
 
 ## Inputs
 
+### `index`
+
+The name of the index to publish to, as defined in the
+`[[tool.uv.index]]` section of your `pyproject.toml`.
+
+See [uv - Publishing your package](https://docs.astral.sh/uv/guides/package/#publishing-your-package)
+for more information on configuring indexes for publishing.
+
+Mutually exclusive with `workspace`, `registry`, and `url`.
+
 ### `workspace`
 
 The workspace being published to.
 
-Mutually exclusive with `url`.
+Mutually exclusive with `index` and `url`.
 
 ### `registry`
 
@@ -114,13 +139,13 @@ The registry being published to, within the [`workspace`](#workspace).
 
 Optional; defaults to the workspace's default registry.
 
-Mutually exclusive with `url`.
+Mutually exclusive with `index` and `url`.
 
 ### <a id="url-input"></a> `url`
 
 The upload URL being published to.
 
-Mutually exclusive with `workspace` and `registry`.
+Mutually exclusive with `index`, `workspace`, and `registry`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,14 @@ branding:
   color: purple
 
 inputs:
+  index:
+    description: |
+      The name of the pyx index (in your `pyproject.toml`) to authenticate against.
+
+      To use this setting, you must have an appropriate `[[tool.uv.index]]`
+      section in your `pyproject.toml`.
+
+      See: https://docs.astral.sh/uv/guides/package/#publishing-your-package
   workspace:
     description: |
       The pyx workspace being published to.
@@ -45,6 +53,7 @@ runs:
         uv run --script "${GITHUB_ACTION_PATH}/action.py"
       shell: bash
       env:
+        GHA_PYX_INPUT_INDEX: ${{ inputs.index }}
         GHA_PYX_INPUT_WORKSPACE: ${{ inputs.workspace }}
         GHA_PYX_INPUT_REGISTRY: ${{ inputs.registry }}
         GHA_PYX_INPUT_URL: ${{ inputs.url }}


### PR DESCRIPTION
This adds an `index: <name>` input to the action, which mirrors the semantics of `uv publish --index <name>` -- `<name>` is matched against the user's `uv.tool.index` table in their `pyproject.toml`, and we use the resulting `publish-url` in that index entry.

One quirk with this input is that it requires the user to have already run `action/checkout` (or similar) such that `pyproject.toml` is readable. That's pretty obvious, but it's different from the other inputs (which are conceptually "pure" in the sense that they don't really need any project state). But this is a sensible tradeoff given the benefits of single-sourcing index configuration 🙂 

Closes #7.

~~Needs tests and documentation.~~