### PR TITLE
test: add an e2e production test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ permissions: {}
 
 env:
   STAGING_PYX_UPLOAD_URL: https://astral-sh-staging-api.pyx.dev/v1/upload/pyx-auth-action/main
-  # most tests use the staging API.
-  GHA_PYX_INPUT_INTERNAL_API_BASE: https://astral-sh-staging-api.pyx.dev
   PYX_API_URL: https://astral-sh-staging-api.pyx.dev
 
 jobs:
@@ -352,7 +350,6 @@ jobs:
     environment: test
 
     env:
-      GHA_PYX_INPUT_INTERNAL_API_BASE: https://api.pyx.dev
       PYX_API_URL: https://api.pyx.dev
 
     steps:

--- a/action.py
+++ b/action.py
@@ -195,8 +195,7 @@ def _main() -> None:
     registry = _get_input("registry")
     raw_url = _get_input("url")
 
-    api_base = _get_input("internal-api-base")
-    assert api_base, "internal-api-base should have a default value"
+    api_base = os.getenv("PYX_API_URL", "https://api.pyx.dev")
 
     # index, workspace/registry, and url are mutually exclusive.
     if sum((bool(index), bool(workspace), bool(raw_url))) != 1:

--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,3 @@ runs:
         GHA_PYX_INPUT_WORKSPACE: ${{ inputs.workspace }}
         GHA_PYX_INPUT_REGISTRY: ${{ inputs.registry }}
         GHA_PYX_INPUT_URL: ${{ inputs.url }}
-        # Not part of the public interface, but allows overriding the API base for testing.
-        GHA_PYX_INPUT_INTERNAL_API_BASE: ${{ env.GHA_PYX_INPUT_INTERNAL_API_BASE || 'https://api.pyx.dev' }}


### PR DESCRIPTION
This will fail until https://github.com/astral-sh/uv/pull/16234 lands in a release.