### PR TITLE
pyproject: fix version, enforce 3.14 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pyx-auth-action"
 version = "0.0.6"
 description = "Get a temporary access token to a pyx registry with Trusted Publishing."
 readme = "README.md"
-dependencies = ["id", "msgspec>=0.19.0", "rfc3986>=2.0.0", "urllib3"]
+dependencies = ["id", "msgspec>=0.20.0", "rfc3986>=2.0.0", "urllib3"]
 requires-python = ">=3.12"
 classifiers = [
     # This is a GitHub Action, not a PyPI package.

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "pyx-auth-action"
-version = "0.0.4"
+version = "0.0.6"
 source = { virtual = "." }
 dependencies = [
     { name = "id" },
@@ -233,7 +233,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "id" },
-    { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "msgspec", specifier = ">=0.20.0" },
     { name = "rfc3986", specifier = ">=2.0.0" },
     { name = "urllib3" },
 ]


### PR DESCRIPTION
3.14 was already supported after my pyproject refactor, this just fully enforces that we only use a 3.14+ compatible msgspec.

Closes #23.

Signed-off-by: William Woodruff <william@astral.sh>