### PR TITLE
Remove default registry API endpoint usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
 
       Example: main
     required: false
+    default: main
   url:
     description: |
       The upload URL.


### PR DESCRIPTION
This removes our use of the dedicated default registry APIs, in favor of treating `main` as the default registry. This is consistent with pyx's own docs and will shortly be enforced anyways.