### PR TITLE
fix: omit dev dependencies at runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: exchange
       id: exchange
       run: |
-        uv run --locked --project "${GITHUB_ACTION_PATH}" "${GITHUB_ACTION_PATH}/action.py"
+        uv run --locked --no-dev --project "${GITHUB_ACTION_PATH}" "${GITHUB_ACTION_PATH}/action.py"
       shell: bash
       env:
         GHA_PYX_INPUT_INDEX: ${{ inputs.index }}


### PR DESCRIPTION
Same as astral-sh/attest-action#61.

Saw the obsolescence warning in the README, but looks like this repo is still being maintained? Feel free to close if not tho :)